### PR TITLE
Changes by Pete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.log
 
-/__pycache__/*
-/dist/*
-/.pytest_cache/*
-/log2d.egg-info/*
+__pycache__/*
+dist/*
+.pytest_cache/*
+log2d.egg-info/*
+
+*.py
+

--- a/tests/test_log2d.py
+++ b/tests/test_log2d.py
@@ -208,9 +208,8 @@ def test_find_ignorecase():
 
 def test_find_path():
     create_dummy_log()
-    result = mylog.find(path="mylog.log", date=timestamp, deltadays=-3)
+    result = Log.find(path="mylog.log", date=timestamp, deltadays=-3)
     assert len(result) == 6, f"FIND14: Anotherlog - Expected 6 lines found {len(result)}"
-
 
 @create_mylog
 def test_find_multiline():

--- a/tests/test_log2d.py
+++ b/tests/test_log2d.py
@@ -1,165 +1,11 @@
 import pytest
-import time
+import logging
+from datetime import datetime, timedelta
 
 from log2d import Log, Path
 
-def test_add_level():
-    """Test by visual inspection of console output"""
-    mylog = Log("mylog")
-    Log.mylog.debug("Debugging message...")
-    mylog.add_level("SUCCESS", 25)
-    Log.mylog.success("Success message...")
-
-def test_cant_add_existing_level():
-    with pytest.raises(AttributeError):
-        mylog = Log("mylog")
-        mylog.add_level("DEBUG", 20)
-
-def test_add_level_above_or_below():
-    mylog = Log("mylog")
-    mylog.add_level("PreError", below="ERROR")
-    Log.mylog.preerror(f"New log level {logging.PREERROR} below ERROR")
-    mylog.add_level("PostInfo", above="INFO")
-    Log.mylog.postinfo(f"New log level {logging.POSTINFO} above INFO ")
-
-def test_defaults():
-    main = Log("main")
-    assert main.name == 'main'
-    assert main.mode == 'a'
-    assert main.path
-    assert main.level == 'debug'
-    assert main.fmt == '%(name)s|%(levelname)-8s|%(asctime)s|%(message)s'
-    assert main.datefmt == '%Y-%m-%dT%H:%M:%S%z'
-    assert main.to_file == False
-    assert main.to_stdout == True
-    assert main.backup_count == 0
-    assert main.logger
-
-def test_file_log():
-    test_log = Log("Test", to_file=True, to_stdout=False)
-    test_log("Entry 1")
-    path = Path("Test.log")
-    assert path.is_file()
-    assert path.read_text().endswith("|Entry 1\n")
-    path.unlink()
-
-def test_shortcut():
-    shortcut = Log("shortcut")
-    shortcut("This should be logged at the default log level (DEBUG)")
-    Log.shortcut.setLevel('CRITICAL')
-    shortcut("This should be logged at the new CRITICAL level")
-    Log.shortcut.info("This should not be logged")
-
-def test_output_destination(capfd):
-    progress_log = Log("Progress", to_file=True)
-    progress_log("Starting")
-    out, err = capfd.readouterr()
-    assert out.endswith("Starting\n")
-    selenium_log = Log("Selenium", to_file=True, to_stdout=False)
-    selenium_log("Started")
-    out, err = capfd.readouterr()
-    assert out == ""
-
-def test_coexist_with_logging():
-    import logging
-    logging.warning("This creates a 'root' logger")
-    from log2d import Log
-    other = Log("other")
-    other("This will be echoed twice - 'root' and 'other'")
-    Log.disable_rootlogger()
-    other("This should only appear once now")
-
-def test_set_level() -> bool:
-    mylog = Log("mylog")
-    success = mylog.add_level("Success", above="INFO")
-    assert success == "New log level 'success' added with value: 21"
-    fail = mylog.add_level("Fail", above="SUCCESS")
-    assert fail == "New log level 'fail' added with value: 22"
-
-    msg = "This should appear in all log levels above DEBUG"
-    mylog.logger.success(f"{msg}: Success!")
-    mylog.logger.info(f"{msg}: Info!")
-    mylog.logger.fail(f"{msg}: Fail!")
-
-    mylog.logger.setLevel('CRITICAL')
-    msg = "This should NOT appear in log levels below CRITICAL"
-    mylog.logger.success(f"{msg}: Success!")
-    mylog.logger.info(f"{msg}: Info!")
-    mylog.logger.fail(f"{msg}: Fail!")
-
-
-@create_mylog
-def test_find() -> bool:
-    """Testing find method"""
-    mylog = Log("findlog")
-
-    mylog.logger.info("A log message - console only")
-    result = mylog.find()
-    assert result[0][:14] == "No log file at", f"FIND1: Found a log file - should be absent!"
-
-    # Create dummy log
-    aWhileAgo = datetime.now()- timedelta(days=8)
-    with open(_fn, "w") as dummyLog:
-        for I in range(6):
-            T = aWhileAgo + timedelta(days=I)
-            dummyLog.write(f"dummylg|INFO    |{T.strftime('%Y-%m-%dT%H:%M:%S%z+0000')}|Log message\n")
-        dummyLog.write("  Here is additional line 1\n   Additional line 2 followed by a blank line\n\n")
-
-    mylog = Log(_log, path=_HPath)
-    msg ="Should be line in log"
-    mylog.logger.info(f"{msg}: Last line")
-    result = mylog.find()
-    assert ": Last line" in result[-1], f"FIND2: Incorrect last record"
-    sleep(1)  # wait a bit
-    T = datetime.now()
-    sleep(1)
-    mylog.logger.critical(f"{msg}: New last line")
-    # Search from T:+1day
-    result = mylog.find(date=T, deltadays=1)
-    assert len(result) == 1, f"FIND3: Expected 1 record, found {len(result)}"
-    assert "CRITICAL" in result[0], f"FIND4: CRITICAL message not found"
-
-    mylog.logger.error(f"{msg}: Yet another last line")
-    result = mylog.find(text="error")
-    assert "ERROR" in result[0], f"FIND5: ERROR message not found"
-    result = mylog.find(text="error", ignorecase=False)
-    assert not result
-    result = mylog.find(level="error")
-    assert len(result) == 2, f"FIND6: Expected 2 records, found {len(result)}"
-
-    # Text searches
-    mylog.logger.warning("This line won't be in search")
-    result = mylog.find('should')
-    assert len(result) > 0, f"FIND7: 'Should' not found"
-    for ln in result:
-        assert "won't" not in ln, f'FIND8: Found "Won\'t" in "{ln}"'
-    result = mylog.find("should", ignorecase=False)
-    assert not result, f"FIND9: Found 'Should' with case sensitive search"
-    result = mylog.find(text='new')
-    assert len(result) == 1, f"FIND10: Expected 1 record, found {len(result)}"
-
-    # Search -5 to -8 days ago
-    T -= timedelta(days=3)
-    result = mylog.find(date=T, deltadays=-3)
-    assert len(result) == 6, f"FIND11: Olddates - Expected 6 records, got {len(result)}"
-    assert not result[-1], f"FIND12: olddates - found last record was '{result[-1]}''"
-    Res2 = mylog.find(date=T, deltadays=-3, autoparse=True)
-    assert result == Res2, f"FIND13: Autoparse - Gives different result"
-
-    lg1 = Log('anotherlog')
-    result = lg1.find(path=_fn, date=T, deltadays=-3)
-    assert len(result) == 6, f"FIND14: Anotherlog - Expected 6 lines found {len(result)}"
-    assert not result[-1], f"FIND15: Anotherlog - found last line was '{result[-1]}'"
-
-    # Tidy up if OK
-    os.remove(_fn)
-
-    print("FIND passes 15 tests OK")
-    return True
-
 def cleanup():
     """ Delete global `mylog` and its log file; delete Handler """
-    print("Deleting: mylog.log")
     if "mylog" in globals():
         global mylog
         for handler in mylog.logger.handlers:
@@ -171,6 +17,7 @@ def cleanup():
     path = Path("mylog.log")
     logging.shutdown()
     if path.is_file():
+        print("Deleting: mylog.log")
         path.unlink()
 
 def create():
@@ -199,6 +46,172 @@ def create_mylog(function):
         return result
     return wrapper
 
+def create_dummy_log():
+    cleanup()
+    a_while_ago = datetime.now()- timedelta(days=8)
+    with open("mylog.log", "w") as file:
+        for index in range(6):
+            timestamp = a_while_ago + timedelta(days=index)
+            file.write(f"mylog|INFO    |{timestamp.strftime('%Y-%m-%dT%H:%M:%S%z+0000')}|Log message\n")
+        file.write("  Here is additional line 1\n   Additional line 2 followed by a blank line\n\n")
+    global mylog
+    mylog = Log("mylog", to_file=True, to_stdout=True)
+    print("Dummy log created: mylog.log")
+
+@create_mylog
+def test_add_level():
+    """Test by visual inspection of console output"""
+    Log.mylog.debug("Debugging message...")
+    mylog.add_level("SUCCESS", 25)
+    Log.mylog.success("Success message...")
+
+@create_mylog
+def test_cant_add_existing_level():
+    with pytest.raises(AttributeError):
+        mylog.add_level("DEBUG", 20)
+
+@create_mylog
+def test_add_level_above_or_below():
+    mylog.add_level("PreError", below="ERROR")
+    Log.mylog.preerror(f"New log level {logging.PREERROR} below ERROR")
+    mylog.add_level("PostInfo", above="INFO")
+    Log.mylog.postinfo(f"New log level {logging.POSTINFO} above INFO ")
+
+def test_defaults():
+    mylog = Log("mylog")
+    assert mylog.name == 'mylog'
+    assert mylog.mode == 'a'
+    assert mylog.path
+    assert mylog.level == 'debug'
+    assert mylog.fmt == '%(name)s|%(levelname)-8s|%(asctime)s|%(message)s'
+    assert mylog.datefmt == '%Y-%m-%dT%H:%M:%S%z'
+    assert mylog.to_file == False
+    assert mylog.to_stdout == True
+    assert mylog.backup_count == 0
+    assert mylog.logger
+    cleanup()
+
+@create_mylog
+def test_file_log():
+    mylog("Entry 1")
+    path = Path("mylog.log")
+    assert path.is_file()
+    assert path.read_text().endswith("|Entry 1\n")
+
+@create_mylog
+def test_shortcut():
+    mylog("This should be logged at the default log level (DEBUG)")
+    Log.mylog.setLevel('CRITICAL')
+    mylog("This should be logged at the new CRITICAL level")
+    Log.mylog.info("This should not be logged")
+
+@create_mylog
+def test_output_destination(capfd):
+    mylog("Starting")
+    out, err = capfd.readouterr()
+    assert out.endswith("Starting\n")
+    selenium_log = Log("Selenium", to_file=True, to_stdout=False)
+    selenium_log("Started")
+    out, err = capfd.readouterr()
+    assert out == ""
+
+@create_mylog
+def test_coexist_with_logging():
+    import logging
+    logging.warning("This creates a 'root' logger")
+    from log2d import Log
+    mylog("This will be echoed twice - 'root' and 'mylog'")
+    Log.disable_rootlogger()
+    mylog("This should only appear once now")
+
+@create_mylog
+def test_set_level() -> bool:
+    success = mylog.add_level("Success", above="INFO")
+    assert success == "New log level 'success' added with value: 21"
+    fail = mylog.add_level("Fail", above="SUCCESS")
+    assert fail.startswith("New log level 'fail' added with value:")
+
+    msg = "This should appear in all log levels above DEBUG"
+    mylog.logger.success(f"{msg}: Success!")
+    mylog.logger.info(f"{msg}: Info!")
+    mylog.logger.fail(f"{msg}: Fail!")
+
+    mylog.logger.setLevel('CRITICAL')
+    msg = "This should NOT appear in log levels below CRITICAL"
+    mylog.logger.success(f"{msg}: Success!")
+    mylog.logger.info(f"{msg}: Info!")
+    mylog.logger.fail(f"{msg}: Fail!")
+    mylog.logger.critical(f"{msg}: Fail!")
+
+
+def test_find_no_file() -> bool:
+    """Testing find method"""
+    mylog = Log("mylog")
+    mylog.logger.info("A log message - console only")
+    with pytest.raises(Exception):
+        result = mylog.find()
+    cleanup()
+
+
+def test_find_text_1():
+    create_dummy_log()
+    mylog.logger.info(f"Message: Last line")
+    result = mylog.find()
+    assert ": Last line" in result[-1], f"FIND2: Incorrect last record"
+
+def test_find_text_2():
+    create_dummy_log()
+    mylog.logger.warning("This line won't be in search")
+    result = mylog.find('Message')
+    assert len(result) > 0, f"FIND7: 'Message' not found"
+    for line in result:
+        assert "won't" not in line, f'FIND8: Found "Won\'t" in "{line}"'
+    cleanup()
+    cleanup()
+
+def test_find_date_1():
+    create_dummy_log()
+    timestamp = datetime.now()
+    mylog.logger.critical(f"Message: New last line")
+    result = mylog.find(date=timestamp, deltadays=1)
+    assert len(result) == 1, f"FIND3: Expected 1 record, found {len(result)}"
+    assert "CRITICAL" in result[0], f"FIND4: CRITICAL message not found"
+    cleanup()
+
+def test_find_by_date_2():
+    create_dummy_log()
+    timestamp -= timedelta(days=3)
+    result = mylog.find(date=timestamp, deltadays=-3)
+    assert len(result) == 6, f"FIND11: Olddates - Expected 6 records, got {len(result)}"
+    result2 = mylog.find(date=timestamp, deltadays=-3, autoparse=True)
+    assert result == result2, f"FIND13: Autoparse - Gives different result"
+
+def test_find_by_level():
+    create_dummy_log()
+    mylog.logger.error(f"Message: Yet another last line")
+    result = mylog.find(text="error")
+    assert "ERROR" in result[0], f"FIND5: ERROR message not found"
+    result = mylog.find(text="error", ignorecase=False)
+    assert not result
+    result = mylog.find(level="error")
+    assert len(result) == 6, f"FIND6: Expected 6 records, found {len(result)}"
+    cleanup()
+
+def test_find_ignorecase():
+    create_dummy_log()
+    result = mylog.find("Message", ignorecase=False)
+    assert not result, f"FIND9: Found 'message' with case sensitive search using 'Message'"
+    result = mylog.find("message", ignorecase=False)
+    assert result, f"FIND9: Failed to find 'message' with case sensitive search"
+    cleanup()
+
+
+def test_find_path():
+    create_dummy_log()
+    result = mylog.find(path="mylog.log", date=timestamp, deltadays=-3)
+    assert len(result) == 6, f"FIND14: Anotherlog - Expected 6 lines found {len(result)}"
+
+
 @create_mylog
 def test_find_multiline():
     Log.mylog.info("Three line message\n\twith more data on this line\n\t\tand also on this line too!")
@@ -221,18 +234,5 @@ def test_find_without_loglevel():
     mylog = Log("mylog", to_file=True, mode="w", to_stdout=True, fmt=fmt)
     mylog("This format has no log level")
     assert len(mylog.find()) == 1
-
-
-"""
-PF Changes:
-
-.find now raises errors rather than returning error messages in a list
-"logname" argument renamed to "path" (shorter, and consistent with Pathlib)
-Test added to check .find keeps individual message strings intact e.g. doesn't strip out \t or \n
-Test added to change `mylog.find(path="another log file.log")` to Classmethod i.e. `Log.find(path="another log file.log")` - that way you don't have to create an instance (mylog) to use it, and also it doesn't make sense to bind a different log file to mylog.
-Variables given longer more descriptive PEP8/snake-case names
-Replaced os.join etc. with pathlib.Path methods
-Added create() and cleanup() utilities to test_log2d for testing
-Added @create_mylog decorator function to test_log2d
-"""
+    cleanup()
 


### PR DESCRIPTION
- .find now raises errors rather than returning error messages in a list
- "logname" argument renamed to "path" (shorter, and consistent with Pathlib)
- Split tests for .find into smaller, more "atomic" individual tests
- Test added to check .find keeps individual message strings intact e.g. doesn't strip out \t or \n
- Test added to change `mylog.find(path="another log file.log")` to Classmethod i.e. `Log.find(path="another log file.log")` - that way you don't have to create an instance (mylog) to use it, and also it doesn't make sense to bind a different log file to mylog.
- Test added for when log format doesn't include loglevel
- Test added to check .find works on e.g. level == "ERRor"
- Variables given longer more descriptive PEP8/snake-case names
- Replaced os.join etc. with pathlib.Path methods
- Added create() and cleanup() utilities to test_log2d for testing
- Added @create_mylog decorator function to test_log2d
